### PR TITLE
feat: implement export functionality for retrospective boards (Fixes #14)

### DIFF
--- a/src/components/RetrospectiveBoard.tsx
+++ b/src/components/RetrospectiveBoard.tsx
@@ -143,7 +143,7 @@ export function RetrospectiveBoard({
   const [exportDialogOpen, setExportDialogOpen] = useState(false);
 
   // Use TanStack Query hooks
-  const { isLoading: retroLoading } = useRetrospective(retrospectiveId);
+  const { data: retrospective, isLoading: retroLoading } = useRetrospective(retrospectiveId);
   const { data: columns = [], isLoading: columnsLoading } = useRetrospectiveColumns(retrospectiveId);
   const { data: items = [], isLoading: itemsLoading } = useRetrospectiveItems(retrospectiveId);
   const { data: votes = [] } = useVotes(retrospectiveId, items.map(i => i.id));
@@ -841,10 +841,12 @@ export function RetrospectiveBoard({
         open={exportDialogOpen}
         onOpenChange={setExportDialogOpen}
         exportData={{
-          retrospectiveName: sprintName,
+          retrospectiveName: retrospective?.title ?? sprintName,
           teamName,
-          sprintName,
-          date: new Date(),
+          sprintName: retrospective?.sprint_name ?? sprintName,
+          date: retrospective?.created_at
+            ? new Date(retrospective.created_at)
+            : new Date(),
           columns,
           items,
           votes,

--- a/src/components/RetrospectiveBoard.tsx
+++ b/src/components/RetrospectiveBoard.tsx
@@ -70,6 +70,8 @@ import { debounce } from "@/lib/utils/debounce";
 import { throttle } from "@/lib/utils/throttle";
 import { isAnonymousItemOwner } from "@/lib/boards/anonymous-items";
 import { sanitizeItemContent, isValidItemText } from "@/lib/utils/sanitize";
+import { ExportDialog } from "@/components/retro/ExportDialog";
+import { Download } from "lucide-react";
 
 interface RetrospectiveBoardProps {
   retrospectiveId: string;
@@ -138,6 +140,7 @@ export function RetrospectiveBoard({
   const [cooldowns, setCooldowns] = useState<Map<string, number>>(new Map());
   const [activeItem, setActiveItem] = useState<RetroItemData | null>(null);
   const [sortByVotes, setSortByVotes] = useState(false);
+  const [exportDialogOpen, setExportDialogOpen] = useState(false);
 
   // Use TanStack Query hooks
   const { isLoading: retroLoading } = useRetrospective(retrospectiveId);
@@ -506,6 +509,17 @@ export function RetrospectiveBoard({
             <ArrowUpDown className="h-4 w-4" />
             Sort by votes
           </Toggle>
+
+          {/* Export Button */}
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setExportDialogOpen(true)}
+            className="gap-1"
+          >
+            <Download className="h-4 w-4" />
+            Export
+          </Button>
           <Badge variant={realtime.connectionStatus === "connected" ? "default" : "secondary"}>
             {realtime.connectionStatus === "connected" ? "Connected" : "Connecting..."}
           </Badge>
@@ -821,6 +835,21 @@ export function RetrospectiveBoard({
           </div>
         )}
       </DragOverlay>
+
+      {/* Export Dialog */}
+      <ExportDialog
+        open={exportDialogOpen}
+        onOpenChange={setExportDialogOpen}
+        exportData={{
+          retrospectiveName: sprintName,
+          teamName,
+          sprintName,
+          date: new Date(),
+          columns,
+          items,
+          votes,
+        }}
+      />
     </div>
     </DndContext>
   );

--- a/src/components/RetrospectiveBoard.tsx
+++ b/src/components/RetrospectiveBoard.tsx
@@ -841,7 +841,7 @@ export function RetrospectiveBoard({
         open={exportDialogOpen}
         onOpenChange={setExportDialogOpen}
         exportData={{
-          retrospectiveName: retrospective?.title ?? sprintName,
+          retrospectiveName: retrospective?.title ?? 'Retrospective',
           teamName,
           sprintName: retrospective?.sprint_name ?? sprintName,
           date: retrospective?.created_at

--- a/src/components/retro/ExportDialog.tsx
+++ b/src/components/retro/ExportDialog.tsx
@@ -23,10 +23,18 @@ import {
   type ExportOptions,
 } from "@/lib/export/retro-export";
 
+const DEFAULT_FILENAME = "retrospective";
+
 // Replace any character not allowed in filenames with '_'
-// This covers Windows and Unix invalid filename characters
-function sanitizeFilename(name: string): string {
-  return name.replace(/[\/\\:*?"<>|]/g, "_");
+// This covers Windows and Unix invalid filename characters plus control chars
+function sanitizeFilename(rawName?: string): string {
+  const candidate = rawName ?? DEFAULT_FILENAME;
+  const sanitized = candidate
+    .replace(/[\x00-\x1f\x7f]/g, "") // Remove control characters
+    .replace(/[\/\\:*?"<>|]/g, "_") // Replace filesystem-invalid chars
+    .trim();
+
+  return sanitized.length > 0 ? sanitized : DEFAULT_FILENAME;
 }
 
 interface ExportDialogProps {
@@ -63,7 +71,7 @@ export function ExportDialog({
 
   const handleDownload = () => {
     try {
-      const safeSprintName = sanitizeFilename(exportData.sprintName || "retrospective");
+      const safeSprintName = sanitizeFilename(exportData.sprintName);
       const filename = `${safeSprintName}-${
         exportData.date.toISOString().split("T")[0]
       }.md`;

--- a/src/components/retro/ExportDialog.tsx
+++ b/src/components/retro/ExportDialog.tsx
@@ -30,7 +30,7 @@ const DEFAULT_FILENAME = "retrospective";
 function sanitizeFilename(rawName?: string): string {
   const candidate = rawName ?? DEFAULT_FILENAME;
   const sanitized = candidate
-    .replace(/[\x00-\x1f\x7f]/g, "") // Remove control characters
+    .replace(/\p{Cc}+/gu, "") // Remove control characters
     .replace(/[\/\\:*?"<>|]/g, "_") // Replace filesystem-invalid chars
     .trim();
 

--- a/src/components/retro/ExportDialog.tsx
+++ b/src/components/retro/ExportDialog.tsx
@@ -55,9 +55,16 @@ export function ExportDialog({
     }
   };
 
+  const sanitizeFilename = (name: string): string => {
+    // Replace any character not allowed in filenames with '_'
+    // This covers Windows and Unix invalid filename characters
+    return name.replace(/[\/\\:*?"<>|]/g, "_");
+  };
+
   const handleDownload = () => {
     try {
-      const filename = `${exportData.sprintName || "retrospective"}-${
+      const safeSprintName = sanitizeFilename(exportData.sprintName || "retrospective");
+      const filename = `${safeSprintName}-${
         exportData.date.toISOString().split("T")[0]
       }.md`;
       downloadMarkdown(markdownContent, filename);

--- a/src/components/retro/ExportDialog.tsx
+++ b/src/components/retro/ExportDialog.tsx
@@ -23,6 +23,12 @@ import {
   type ExportOptions,
 } from "@/lib/export/retro-export";
 
+// Replace any character not allowed in filenames with '_'
+// This covers Windows and Unix invalid filename characters
+function sanitizeFilename(name: string): string {
+  return name.replace(/[\/\\:*?"<>|]/g, "_");
+}
+
 interface ExportDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
@@ -53,12 +59,6 @@ export function ExportDialog({
       console.error("Failed to copy to clipboard:", error);
       toast.error("Failed to copy to clipboard");
     }
-  };
-
-  const sanitizeFilename = (name: string): string => {
-    // Replace any character not allowed in filenames with '_'
-    // This covers Windows and Unix invalid filename characters
-    return name.replace(/[\/\\:*?"<>|]/g, "_");
   };
 
   const handleDownload = () => {

--- a/src/components/retro/ExportDialog.tsx
+++ b/src/components/retro/ExportDialog.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+import { Download, Copy, FileText } from "lucide-react";
+import { toast } from "sonner";
+import {
+  formatMarkdownExport,
+  downloadMarkdown,
+  copyToClipboard,
+  type ExportData,
+  type ExportOptions,
+} from "@/lib/export/retro-export";
+
+interface ExportDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  exportData: ExportData;
+}
+
+export function ExportDialog({
+  open,
+  onOpenChange,
+  exportData,
+}: ExportDialogProps) {
+  const [options, setOptions] = useState<ExportOptions>({
+    grouped: true,
+    includeVotes: true,
+    includeMetadata: true,
+  });
+
+  const markdownContent = formatMarkdownExport(exportData, options);
+
+  const handleCopyToClipboard = async () => {
+    try {
+      await copyToClipboard(markdownContent);
+      toast.success("Copied to clipboard!", {
+        description: "Retrospective exported as Markdown",
+        duration: 3000,
+      });
+    } catch (error) {
+      console.error("Failed to copy to clipboard:", error);
+      toast.error("Failed to copy to clipboard");
+    }
+  };
+
+  const handleDownload = () => {
+    try {
+      const filename = `${exportData.sprintName || "retrospective"}-${
+        exportData.date.toISOString().split("T")[0]
+      }.md`;
+      downloadMarkdown(markdownContent, filename);
+      toast.success("Downloaded successfully!", {
+        description: filename,
+        duration: 3000,
+      });
+    } catch (error) {
+      console.error("Failed to download file:", error);
+      toast.error("Failed to download file");
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-3xl max-h-[80vh]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <FileText className="h-5 w-5" />
+            Export Retrospective
+          </DialogTitle>
+          <DialogDescription>
+            Export your retrospective in Markdown format to share with
+            stakeholders.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="space-y-3">
+            <div className="flex items-center justify-between">
+              <Label htmlFor="grouped-export" className="flex flex-col gap-1">
+                <span>Grouped by Columns</span>
+                <span className="text-xs text-muted-foreground font-normal">
+                  Organize items by their respective columns
+                </span>
+              </Label>
+              <Switch
+                id="grouped-export"
+                checked={options.grouped}
+                onCheckedChange={(checked) =>
+                  setOptions({ ...options, grouped: checked })
+                }
+              />
+            </div>
+
+            <div className="flex items-center justify-between">
+              <Label htmlFor="include-votes" className="flex flex-col gap-1">
+                <span>Include Vote Counts</span>
+                <span className="text-xs text-muted-foreground font-normal">
+                  Show the number of votes each item received
+                </span>
+              </Label>
+              <Switch
+                id="include-votes"
+                checked={options.includeVotes}
+                onCheckedChange={(checked) =>
+                  setOptions({ ...options, includeVotes: checked })
+                }
+              />
+            </div>
+
+            <div className="flex items-center justify-between">
+              <Label htmlFor="include-metadata" className="flex flex-col gap-1">
+                <span>Include Metadata</span>
+                <span className="text-xs text-muted-foreground font-normal">
+                  Add header with team name, sprint, and date
+                </span>
+              </Label>
+              <Switch
+                id="include-metadata"
+                checked={options.includeMetadata}
+                onCheckedChange={(checked) =>
+                  setOptions({ ...options, includeMetadata: checked })
+                }
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Preview</Label>
+            <Textarea
+              value={markdownContent}
+              readOnly
+              className="font-mono text-sm min-h-[300px] resize-none"
+            />
+          </div>
+        </div>
+
+        <DialogFooter className="gap-2 sm:gap-0">
+          <Button variant="outline" onClick={handleCopyToClipboard}>
+            <Copy className="h-4 w-4 mr-2" />
+            Copy to Clipboard
+          </Button>
+          <Button onClick={handleDownload}>
+            <Download className="h-4 w-4 mr-2" />
+            Download Markdown
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/lib/export/__tests__/retro-export.test.ts
+++ b/src/lib/export/__tests__/retro-export.test.ts
@@ -1,4 +1,3 @@
-import { describe, it, expect, beforeEach } from "vitest";
 import { formatMarkdownExport, type ExportData } from "../retro-export";
 
 describe("formatMarkdownExport", () => {

--- a/src/lib/export/__tests__/retro-export.test.ts
+++ b/src/lib/export/__tests__/retro-export.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { formatMarkdownExport, type ExportData } from "../retro-export";
+
+describe("formatMarkdownExport", () => {
+  let mockExportData: ExportData;
+
+  beforeEach(() => {
+    mockExportData = {
+      retrospectiveName: "Sprint 10 Retrospective",
+      teamName: "Development Team",
+      sprintName: "Sprint 10",
+      date: new Date("2024-01-15T12:00:00Z"),
+      columns: [
+        {
+          id: "col-1",
+          retrospective_id: "retro-1",
+          title: "What went well",
+          description: "Things that went well",
+          column_type: "went-well",
+          display_order: 1,
+          color: null,
+          created_at: "2024-01-15T12:00:00Z",
+        },
+        {
+          id: "col-2",
+          retrospective_id: "retro-1",
+          title: "What could be improved",
+          description: "Areas for improvement",
+          column_type: "improve",
+          display_order: 2,
+          color: null,
+          created_at: "2024-01-15T12:00:00Z",
+        },
+        {
+          id: "col-3",
+          retrospective_id: "retro-1",
+          title: "Action Items",
+          description: "Action items",
+          column_type: "action-items",
+          display_order: 3,
+          color: null,
+          created_at: "2024-01-15T12:00:00Z",
+        },
+      ],
+      items: [
+        {
+          id: "item-1",
+          retrospective_id: "retro-1",
+          column_id: "col-1",
+          text: "Great team collaboration",
+          author_id: "user-1",
+          author_name: "John Doe",
+          created_at: "2024-01-15T12:00:00Z",
+          updated_at: null,
+          position: 0,
+          color: null,
+        },
+        {
+          id: "item-2",
+          retrospective_id: "retro-1",
+          column_id: "col-2",
+          text: "Need better documentation",
+          author_id: "user-2",
+          author_name: "Jane Smith",
+          created_at: "2024-01-15T12:00:00Z",
+          updated_at: null,
+          position: 0,
+          color: null,
+        },
+        {
+          id: "item-3",
+          retrospective_id: "retro-1",
+          column_id: "col-3",
+          text: "Update API documentation",
+          author_id: "user-1",
+          author_name: "John Doe",
+          created_at: "2024-01-15T12:00:00Z",
+          updated_at: null,
+          position: 0,
+          color: null,
+        },
+      ],
+      votes: [
+        {
+          id: "vote-1",
+          profile_id: "user-1",
+          item_id: "item-1",
+          retrospective_id: "retro-1",
+          created_at: "2024-01-15T12:00:00Z",
+        },
+        {
+          id: "vote-2",
+          profile_id: "user-2",
+          item_id: "item-1",
+          retrospective_id: "retro-1",
+          created_at: "2024-01-15T12:00:00Z",
+        },
+        {
+          id: "vote-3",
+          profile_id: "user-3",
+          item_id: "item-2",
+          retrospective_id: "retro-1",
+          created_at: "2024-01-15T12:00:00Z",
+        },
+      ],
+    };
+  });
+
+  it("should format markdown with grouped items by default", () => {
+    const result = formatMarkdownExport(mockExportData, {
+      grouped: true,
+      includeVotes: true,
+      includeMetadata: true,
+    });
+
+    expect(result).toContain("# Sprint 10 Retrospective");
+    expect(result).toContain("**Team:** Development Team");
+    expect(result).toContain("**Sprint:** Sprint 10");
+    expect(result).toContain("## What went well");
+    expect(result).toContain("## What could be improved");
+    expect(result).toContain("Great team collaboration");
+    expect(result).toContain("Need better documentation");
+  });
+
+  it("should include vote counts when enabled", () => {
+    const result = formatMarkdownExport(mockExportData, {
+      grouped: true,
+      includeVotes: true,
+      includeMetadata: true,
+    });
+
+    expect(result).toContain("(2 👍)");
+    expect(result).toContain("(1 👍)");
+  });
+
+  it("should exclude vote counts when disabled", () => {
+    const result = formatMarkdownExport(mockExportData, {
+      grouped: true,
+      includeVotes: false,
+      includeMetadata: true,
+    });
+
+    expect(result).not.toContain("👍");
+  });
+
+  it("should format as ungrouped when grouped is false", () => {
+    const result = formatMarkdownExport(mockExportData, {
+      grouped: false,
+      includeVotes: true,
+      includeMetadata: true,
+    });
+
+    expect(result).toContain("## All Items");
+    expect(result).toContain("**[What went well]**");
+    expect(result).toContain("**[What could be improved]**");
+  });
+
+  it("should include author names", () => {
+    const result = formatMarkdownExport(mockExportData, {
+      grouped: true,
+      includeVotes: true,
+      includeMetadata: true,
+    });
+
+    expect(result).toContain("*John Doe*");
+    expect(result).toContain("*Jane Smith*");
+  });
+
+  it("should exclude metadata when disabled", () => {
+    const result = formatMarkdownExport(mockExportData, {
+      grouped: true,
+      includeVotes: true,
+      includeMetadata: false,
+    });
+
+    expect(result).not.toContain("# Sprint 10 Retrospective");
+    expect(result).not.toContain("**Team:** Development Team");
+    expect(result).toContain("## What went well");
+  });
+
+  it("should handle action items in ungrouped mode", () => {
+    const result = formatMarkdownExport(mockExportData, {
+      grouped: false,
+      includeVotes: true,
+      includeMetadata: true,
+    });
+
+    expect(result).toContain("## Action Items");
+    expect(result).toContain("- [ ] Update API documentation");
+  });
+
+  it("should handle empty columns", () => {
+    const emptyData = {
+      ...mockExportData,
+      items: [],
+    };
+
+    const result = formatMarkdownExport(emptyData, {
+      grouped: true,
+      includeVotes: true,
+      includeMetadata: true,
+    });
+
+    expect(result).toContain("*No items*");
+  });
+
+  it("should sort items by vote count", () => {
+    const result = formatMarkdownExport(mockExportData, {
+      grouped: true,
+      includeVotes: true,
+      includeMetadata: true,
+    });
+
+    const item1Index = result.indexOf("Great team collaboration");
+    const item2Index = result.indexOf("Need better documentation");
+
+    expect(item1Index).toBeLessThan(item2Index);
+  });
+
+  it("should include generation timestamp", () => {
+    const result = formatMarkdownExport(mockExportData, {
+      grouped: true,
+      includeVotes: true,
+      includeMetadata: true,
+    });
+
+    expect(result).toContain("*Generated on");
+  });
+});

--- a/src/lib/export/retro-export.ts
+++ b/src/lib/export/retro-export.ts
@@ -1,0 +1,159 @@
+import type { Database } from "@/lib/supabase/types-enhanced";
+
+type RetrospectiveItem = Database["public"]["Tables"]["retrospective_items"]["Row"];
+type RetrospectiveColumn = Database["public"]["Tables"]["retrospective_columns"]["Row"];
+type Vote = Database["public"]["Tables"]["votes"]["Row"];
+
+export interface ExportData {
+  retrospectiveName: string;
+  teamName: string;
+  sprintName?: string;
+  date: Date;
+  columns: RetrospectiveColumn[];
+  items: RetrospectiveItem[];
+  votes: Vote[];
+}
+
+export interface ExportOptions {
+  grouped: boolean;
+  includeVotes: boolean;
+  includeMetadata: boolean;
+}
+
+export function formatMarkdownExport(
+  data: ExportData,
+  options: ExportOptions = {
+    grouped: true,
+    includeVotes: true,
+    includeMetadata: true,
+  }
+): string {
+  const lines: string[] = [];
+
+  if (options.includeMetadata) {
+    lines.push(`# ${data.retrospectiveName || "Sprint Retrospective"}`);
+    lines.push("");
+    lines.push(`**Team:** ${data.teamName}`);
+    if (data.sprintName) {
+      lines.push(`**Sprint:** ${data.sprintName}`);
+    }
+    lines.push(`**Date:** ${data.date.toLocaleDateString()}`);
+    lines.push("");
+    lines.push("---");
+    lines.push("");
+  }
+
+  const voteCountMap = new Map<string, number>();
+  for (const vote of data.votes) {
+    voteCountMap.set(vote.item_id, (voteCountMap.get(vote.item_id) || 0) + 1);
+  }
+
+  if (options.grouped) {
+    const sortedColumns = [...data.columns].sort(
+      (a, b) => (a.display_order || 0) - (b.display_order || 0)
+    );
+
+    for (const column of sortedColumns) {
+      lines.push(`## ${column.title}`);
+      if (column.description) {
+        lines.push("");
+        lines.push(`*${column.description}*`);
+      }
+      lines.push("");
+
+      const columnItems = data.items
+        .filter((item) => item.column_id === column.id)
+        .sort((a, b) => {
+          const aVotes = voteCountMap.get(a.id) || 0;
+          const bVotes = voteCountMap.get(b.id) || 0;
+          if (aVotes !== bVotes) return bVotes - aVotes;
+          return (
+            new Date(b.created_at || 0).getTime() -
+            new Date(a.created_at || 0).getTime()
+          );
+        });
+
+      if (columnItems.length === 0) {
+        lines.push("*No items*");
+        lines.push("");
+      } else {
+        for (const item of columnItems) {
+          const votes = voteCountMap.get(item.id) || 0;
+          const voteText = options.includeVotes && votes > 0 ? ` (${votes} 👍)` : "";
+          const authorText = item.author_name ? ` - *${item.author_name}*` : "";
+          lines.push(`- ${item.text}${voteText}${authorText}`);
+        }
+        lines.push("");
+      }
+    }
+  } else {
+    lines.push(`## All Items`);
+    lines.push("");
+
+    const allItems = [...data.items].sort((a, b) => {
+      const aVotes = voteCountMap.get(a.id) || 0;
+      const bVotes = voteCountMap.get(b.id) || 0;
+      if (aVotes !== bVotes) return bVotes - aVotes;
+      return (
+        new Date(b.created_at || 0).getTime() -
+        new Date(a.created_at || 0).getTime()
+      );
+    });
+
+    for (const item of allItems) {
+      const column = data.columns.find((c) => c.id === item.column_id);
+      const votes = voteCountMap.get(item.id) || 0;
+      const voteText = options.includeVotes && votes > 0 ? ` (${votes} 👍)` : "";
+      const authorText = item.author_name ? ` - *${item.author_name}*` : "";
+      const columnText = column ? ` **[${column.title}]**` : "";
+      lines.push(`- ${item.text}${voteText}${authorText}${columnText}`);
+    }
+    lines.push("");
+  }
+
+  const actionItemsColumn = data.columns.find(
+    (c) => c.column_type === "action-items"
+  );
+  if (actionItemsColumn) {
+    const actionItems = data.items.filter(
+      (item) => item.column_id === actionItemsColumn.id
+    );
+
+    if (actionItems.length > 0 && !options.grouped) {
+      lines.push("---");
+      lines.push("");
+      lines.push("## Action Items");
+      lines.push("");
+
+      for (const item of actionItems) {
+        const votes = voteCountMap.get(item.id) || 0;
+        const voteText = options.includeVotes && votes > 0 ? ` (${votes} 👍)` : "";
+        const authorText = item.author_name ? ` - *${item.author_name}*` : "";
+        lines.push(`- [ ] ${item.text}${voteText}${authorText}`);
+      }
+      lines.push("");
+    }
+  }
+
+  lines.push("---");
+  lines.push("");
+  lines.push(`*Generated on ${new Date().toLocaleString()}*`);
+
+  return lines.join("\n");
+}
+
+export function downloadMarkdown(content: string, filename: string): void {
+  const blob = new Blob([content], { type: "text/markdown;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+export async function copyToClipboard(content: string): Promise<void> {
+  await navigator.clipboard.writeText(content);
+}

--- a/src/lib/export/retro-export.ts
+++ b/src/lib/export/retro-export.ts
@@ -68,8 +68,8 @@ export function formatMarkdownExport(
           const bVotes = voteCountMap.get(b.id) || 0;
           if (aVotes !== bVotes) return bVotes - aVotes;
           return (
-            new Date(b.created_at || 0).getTime() -
-            new Date(a.created_at || 0).getTime()
+            new Date(b.created_at ?? Date.now()).getTime() -
+            new Date(a.created_at ?? Date.now()).getTime()
           );
         });
 
@@ -95,8 +95,8 @@ export function formatMarkdownExport(
       const bVotes = voteCountMap.get(b.id) || 0;
       if (aVotes !== bVotes) return bVotes - aVotes;
       return (
-        new Date(b.created_at || 0).getTime() -
-        new Date(a.created_at || 0).getTime()
+        new Date(b.created_at ?? Date.now()).getTime() -
+        new Date(a.created_at ?? Date.now()).getTime()
       );
     });
 


### PR DESCRIPTION
## Summary
- Implement Markdown export functionality for retrospective boards
- Add grouped and ungrouped export options as requested
- Include vote counts in exported content  
- Generate dedicated action items section for ungrouped exports
- Add copy to clipboard and download functionality

## Features Implemented
✅ **Markdown Export Formatter** - Clean, structured markdown output  
✅ **Grouped vs Ungrouped Export** - Toggle between organizational views  
✅ **Vote Count Integration** - Display voting results in exports  
✅ **Action Items Section** - Dedicated section for action items (ungrouped mode)  
✅ **Copy to Clipboard** - One-click copying with user feedback  
✅ **Download as File** - Save exports as `.md` files  

## Technical Implementation  
- **Export utilities**: `src/lib/export/retro-export.ts`
- **UI Dialog**: `src/components/retro/ExportDialog.tsx`  
- **Integration**: Added export button to RetrospectiveBoard header
- **Testing**: Comprehensive unit tests for export formatting

## Export Format Examples

### Grouped Export
```markdown
# Sprint 10 Retrospective

**Team:** Development Team
**Sprint:** Sprint 10  
**Date:** 1/15/2024

## What went well
- Great team collaboration (3 👍) - *John Doe*
- Code reviews improved quality (2 👍) - *Jane Smith*

## What could be improved  
- Need better documentation (1 👍) - *Bob Wilson*
```

### Ungrouped Export
```markdown
# Sprint 10 Retrospective

## All Items
- Great team collaboration (3 👍) - *John Doe* **[What went well]**
- Code reviews improved quality (2 👍) - *Jane Smith* **[What went well]**

## Action Items
- [ ] Update API documentation (1 👍) - *Bob Wilson*
```

## Test plan
- [x] Export button appears in retrospective board header
- [x] Export dialog opens with proper UI controls
- [x] Grouped export formats items by column
- [x] Ungrouped export shows flat list with column tags
- [x] Vote counts are included when enabled
- [x] Author names are properly attributed
- [x] Copy to clipboard works with success feedback
- [x] Download generates properly named .md files
- [x] Action items section appears in ungrouped mode
- [x] All export options (grouped, votes, metadata) work correctly
- [x] Unit tests pass for all formatting scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Export retrospectives to Markdown from the board via an Export button and modal with live preview and options (grouped, include votes, include metadata).
  * Copy-to-clipboard and download-as-.md actions with success/error toasts and sanitized filenames.
  * Export supports grouped or all-items views, vote counts, author attribution, action-item section, empty-column indicators, and a generation timestamp; items sorted by votes and recency.

* **Tests**
  * Comprehensive tests covering export formatting across options and data scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->