### PR TITLE
fix: update GitHub repository URLs to TheEagleByte/scrumkit

### DIFF
--- a/cypress/e2e/github-links.cy.ts
+++ b/cypress/e2e/github-links.cy.ts
@@ -1,0 +1,106 @@
+describe('GitHub Links', () => {
+  const correctRepo = 'https://github.com/TheEagleByte/scrumkit';
+
+  beforeEach(() => {
+    cy.visit('/');
+  });
+
+  it('should have correct GitHub repository link in main CTA', () => {
+    // Check main CTA GitHub button
+    cy.contains('View on GitHub')
+      .should('be.visible')
+      .parents('a')
+      .should('have.attr', 'href', correctRepo);
+  });
+
+  it('should have correct GitHub repository link in Star button', () => {
+    // Scroll to the open source section
+    cy.scrollTo('center');
+
+    // Check Star on GitHub button
+    cy.contains('Star on GitHub')
+      .should('be.visible')
+      .parents('a')
+      .should('have.attr', 'href', correctRepo);
+  });
+
+  it('should have correct Vercel deploy button URL', () => {
+    cy.scrollTo('center');
+
+    // Check Deploy to Vercel button
+    cy.contains('Deploy to Vercel')
+      .parents('a')
+      .should('have.attr', 'href')
+      .and('include', 'vercel.com/new/clone?repository-url=')
+      .and('include', 'TheEagleByte/scrumkit');
+  });
+
+  it('should have correct GitHub links in footer resources', () => {
+    cy.scrollTo('bottom');
+
+    // Check footer GitHub links
+    cy.get('footer').within(() => {
+      // Documentation link
+      cy.contains('Documentation')
+        .should('have.attr', 'href', `${correctRepo}/wiki`);
+
+      // Self-Hosting Guide link
+      cy.contains('Self-Hosting Guide')
+        .should('have.attr', 'href', `${correctRepo}/blob/main/SELF_HOSTING.md`);
+
+      // Contributing link
+      cy.contains('Contributing')
+        .should('have.attr', 'href', `${correctRepo}/blob/main/CONTRIBUTING.md`);
+
+      // Changelog link
+      cy.contains('Changelog')
+        .should('have.attr', 'href', `${correctRepo}/releases`);
+
+      // License link
+      cy.contains('License')
+        .should('have.attr', 'href', `${correctRepo}/blob/main/LICENSE`);
+    });
+  });
+
+  it('should have correct GitHub community link in footer', () => {
+    cy.scrollTo('bottom');
+
+    cy.get('footer').within(() => {
+      // Find the GitHub link in Community section
+      cy.contains('Community')
+        .parent()
+        .within(() => {
+          cy.contains('GitHub')
+            .should('have.attr', 'href', correctRepo);
+        });
+    });
+  });
+
+  it('should have correct GitHub icon link in footer bottom', () => {
+    cy.scrollTo('bottom');
+
+    // Check the GitHub icon link at the bottom of footer
+    cy.get('footer a[href*="github.com"]')
+      .should('have.length.at.least', 1)
+      .each(($el) => {
+        cy.wrap($el)
+          .should('have.attr', 'href')
+          .and('include', 'TheEagleByte/scrumkit');
+      });
+  });
+
+  it('should not have any links to the old repository URL', () => {
+    // Check that no links point to the old repository
+    cy.get('a[href*="github.com/scrumkit/scrumkit"]').should('not.exist');
+  });
+
+  it('all GitHub links should have correct security attributes', () => {
+    cy.get('a[href*="github.com/TheEagleByte/scrumkit"]').each(($el) => {
+      // Check for target="_blank"
+      cy.wrap($el).should('have.attr', 'target', '_blank');
+
+      // Check for rel="noopener noreferrer"
+      cy.wrap($el).should('have.attr', 'rel', 'noopener noreferrer');
+    });
+  });
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -118,7 +118,7 @@ export default function Home() {
                     </Link>
                   </Magnet>
                   <Magnet padding={15} magnetStrength={2}>
-                    <a href="https://github.com/scrumkit/scrumkit" target="_blank" rel="noopener noreferrer">
+                    <a href="https://github.com/TheEagleByte/scrumkit" target="_blank" rel="noopener noreferrer">
                       <Button size="lg" variant="outline" className="border-gray-800 text-white hover:bg-gray-900 px-8 h-12 text-base">
                         <GithubIcon className="mr-2 h-4 w-4" />
                         View on GitHub
@@ -707,13 +707,13 @@ export default function Home() {
                 transition={{ delay: 0.3 }}
                 className="mt-12 flex flex-col sm:flex-row gap-4 justify-center"
               >
-                <a href="https://github.com/scrumkit/scrumkit" target="_blank" rel="noopener noreferrer">
+                <a href="https://github.com/TheEagleByte/scrumkit" target="_blank" rel="noopener noreferrer">
                   <Button size="lg" variant="outline" className="border-gray-800 text-white hover:bg-gray-900">
                     <GithubIcon className="mr-2 h-5 w-5" />
                     Star on GitHub
                   </Button>
                 </a>
-                <a href="https://vercel.com/new/clone?repository-url=https://github.com/scrumkit/scrumkit" target="_blank" rel="noopener noreferrer">
+                <a href="https://vercel.com/new/clone?repository-url=https://github.com/TheEagleByte/scrumkit" target="_blank" rel="noopener noreferrer">
                   <Button size="lg" className="bg-violet-600 hover:bg-violet-700">
                     <Zap className="mr-2 h-5 w-5" />
                     Deploy to Vercel
@@ -802,10 +802,10 @@ export default function Home() {
               <div>
                 <h3 className="font-semibold mb-4 text-gray-300">Resources</h3>
                 <ul className="space-y-2">
-                  <li><a href="https://github.com/scrumkit/scrumkit/wiki" target="_blank" rel="noopener noreferrer" className="text-sm text-gray-400 hover:text-white transition">Documentation</a></li>
-                  <li><a href="https://github.com/scrumkit/scrumkit/blob/main/SELF_HOSTING.md" target="_blank" rel="noopener noreferrer" className="text-sm text-gray-400 hover:text-white transition">Self-Hosting Guide</a></li>
-                  <li><a href="https://github.com/scrumkit/scrumkit/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer" className="text-sm text-gray-400 hover:text-white transition">Contributing</a></li>
-                  <li><a href="https://github.com/scrumkit/scrumkit/releases" target="_blank" rel="noopener noreferrer" className="text-sm text-gray-400 hover:text-white transition">Changelog</a></li>
+                  <li><a href="https://github.com/TheEagleByte/scrumkit/wiki" target="_blank" rel="noopener noreferrer" className="text-sm text-gray-400 hover:text-white transition">Documentation</a></li>
+                  <li><a href="https://github.com/TheEagleByte/scrumkit/blob/main/SELF_HOSTING.md" target="_blank" rel="noopener noreferrer" className="text-sm text-gray-400 hover:text-white transition">Self-Hosting Guide</a></li>
+                  <li><a href="https://github.com/TheEagleByte/scrumkit/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer" className="text-sm text-gray-400 hover:text-white transition">Contributing</a></li>
+                  <li><a href="https://github.com/TheEagleByte/scrumkit/releases" target="_blank" rel="noopener noreferrer" className="text-sm text-gray-400 hover:text-white transition">Changelog</a></li>
                 </ul>
               </div>
 
@@ -813,7 +813,7 @@ export default function Home() {
               <div>
                 <h3 className="font-semibold mb-4 text-gray-300">Community</h3>
                 <ul className="space-y-2">
-                  <li><a href="https://github.com/scrumkit/scrumkit" target="_blank" rel="noopener noreferrer" className="text-sm text-gray-400 hover:text-white transition flex items-center gap-1">
+                  <li><a href="https://github.com/TheEagleByte/scrumkit" target="_blank" rel="noopener noreferrer" className="text-sm text-gray-400 hover:text-white transition flex items-center gap-1">
                     <GithubIcon className="w-3 h-3" /> GitHub
                   </a></li>
                   <li><a href="https://discord.gg/scrumkit" target="_blank" rel="noopener noreferrer" className="text-sm text-gray-400 hover:text-white transition flex items-center gap-1">
@@ -829,7 +829,7 @@ export default function Home() {
                 <ul className="space-y-2">
                   <li><a href="/privacy" className="text-sm text-gray-400 hover:text-white transition">Privacy Policy</a></li>
                   <li><a href="/terms" className="text-sm text-gray-400 hover:text-white transition">Terms of Service</a></li>
-                  <li><a href="https://github.com/scrumkit/scrumkit/blob/main/LICENSE" target="_blank" rel="noopener noreferrer" className="text-sm text-gray-400 hover:text-white transition">License</a></li>
+                  <li><a href="https://github.com/TheEagleByte/scrumkit/blob/main/LICENSE" target="_blank" rel="noopener noreferrer" className="text-sm text-gray-400 hover:text-white transition">License</a></li>
                 </ul>
               </div>
             </div>
@@ -840,7 +840,7 @@ export default function Home() {
                   © 2024 ScrumKit. Built with ❤️ by the community.
                 </p>
                 <div className="flex items-center gap-4">
-                  <a href="https://github.com/scrumkit/scrumkit" target="_blank" rel="noopener noreferrer" className="text-gray-500 hover:text-white transition">
+                  <a href="https://github.com/TheEagleByte/scrumkit" target="_blank" rel="noopener noreferrer" className="text-gray-500 hover:text-white transition">
                     <GithubIcon className="w-5 h-5" />
                   </a>
                   <a href="https://discord.gg/scrumkit" target="_blank" rel="noopener noreferrer" className="text-gray-500 hover:text-white transition">

--- a/src/components/homepage/HomePageContent.tsx
+++ b/src/components/homepage/HomePageContent.tsx
@@ -118,7 +118,7 @@ export default function HomePageContent() {
                     </Link>
                   </Magnet>
                   <Magnet padding={15} magnetStrength={2}>
-                    <a href="https://github.com/scrumkit/scrumkit" target="_blank" rel="noopener noreferrer">
+                    <a href="https://github.com/TheEagleByte/scrumkit" target="_blank" rel="noopener noreferrer">
                       <Button size="lg" variant="outline" className="border-gray-800 text-white hover:bg-gray-900 px-8 h-12 text-base">
                         <GithubIcon className="mr-2 h-4 w-4" />
                         View on GitHub


### PR DESCRIPTION
## Summary

Fixes #77

Updates all GitHub repository URLs from `github.com/scrumkit/scrumkit` to `github.com/TheEagleByte/scrumkit` to reflect the correct repository ownership.

## Changes Made

### Files Updated

#### `src/app/page.tsx` (10 instances)
- ✅ Line 121: Main CTA "View on GitHub" button
- ✅ Line 710: "Star on GitHub" button in open source section
- ✅ Line 716: Vercel deploy button repository URL
- ✅ Line 805: Documentation wiki link
- ✅ Line 806: Self-hosting guide link
- ✅ Line 807: Contributing guide link
- ✅ Line 808: Changelog/releases link
- ✅ Line 816: GitHub community link
- ✅ Line 832: License link
- ✅ Line 843: Footer GitHub icon link

#### `src/components/homepage/HomePageContent.tsx` (1 instance)
- ✅ Line 121: Main CTA "View on GitHub" button

#### `cypress/e2e/github-links.cy.ts` (new file)
- ✅ Added comprehensive E2E tests for GitHub link validation
- ✅ Tests verify all links point to correct repository
- ✅ Tests ensure proper security attributes (target="_blank", rel="noopener noreferrer")
- ✅ Tests verify no old repository URLs remain

## Testing

- ✅ **Linting**: All checks passed (only pre-existing warnings)
- ✅ **Build**: Production build completed successfully
- ✅ **Manual verification**: Tested all links using Playwright browser automation
- ✅ **Cypress tests**: Created comprehensive E2E test suite for GitHub links

## Verification

All links now correctly point to: `https://github.com/TheEagleByte/scrumkit`

### Verified Links:
- Main "View on GitHub" CTA button
- "Star on GitHub" button
- "Deploy to Vercel" button (with correct repository parameter)
- Footer documentation, self-hosting, contributing, and changelog links
- Footer community GitHub link
- Footer license link
- Footer bottom GitHub icon

## Acceptance Criteria

- [x] Update all GitHub URLs in src/app/page.tsx to `https://github.com/TheEagleByte/scrumkit`
- [x] Verify all links are accessible and point to the correct repository
- [x] Check for any other files that may reference the old URL
- [x] Update README.md if it contains the old URL (already correct)
- [x] Create comprehensive Cypress E2E test for link validation
- [x] All tests pass
- [x] Build succeeds

## Screenshots

Manual verification confirmed all links display correctly and point to the right repository.