### PR TITLE
fix: remove non-existent Twitter link from footer

### DIFF
--- a/cypress/e2e/footer-links.cy.ts
+++ b/cypress/e2e/footer-links.cy.ts
@@ -1,0 +1,17 @@
+describe('Footer Links', () => {
+  it('should not have Twitter link', () => {
+    cy.visit('/');
+    cy.get('footer').within(() => {
+      cy.contains('Twitter').should('not.exist');
+      cy.get('a[href*="twitter.com"]').should('not.exist');
+    });
+  });
+
+  it('should have GitHub and Discord links', () => {
+    cy.visit('/');
+    cy.get('footer').within(() => {
+      cy.contains('GitHub').should('exist');
+      cy.contains('Discord').should('exist');
+    });
+  });
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -829,7 +829,6 @@ export default function Home() {
                   <li><a href="https://discord.gg/scrumkit" target="_blank" rel="noopener noreferrer" className="text-sm text-gray-400 hover:text-white transition flex items-center gap-1">
                     <MessageSquare className="w-3 h-3" /> Discord
                   </a></li>
-                  <li><a href="https://twitter.com/scrumkit" target="_blank" rel="noopener noreferrer" className="text-sm text-gray-400 hover:text-white transition">Twitter</a></li>
                 </ul>
               </div>
 


### PR DESCRIPTION
## Summary
- Removed Twitter link from footer Community section (no official Twitter/X presence exists)
- GitHub and Discord links remain intact
- Added Cypress E2E test to verify the change

## Changes Made
- **src/app/page.tsx**: Removed Twitter link from Community section footer
- **cypress/e2e/footer-links.cy.ts**: Added E2E test to verify Twitter link removal and confirm GitHub/Discord links exist

## Testing
- ✅ Linter passed (warnings only, no errors)
- ✅ Build completed successfully
- ✅ Cypress E2E test added to verify footer links

## Closes
Closes #79

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Updated footer Community links: removed Twitter; GitHub and Discord remain accessible.

- Tests
  - Added end-to-end tests to verify footer links:
    - Confirms Twitter link is absent.
    - Confirms GitHub and Discord links are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->