### PR TITLE
Add password confirmation field to signup form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Password Confirmation Field on Signup Form** (Issue #89)
+  - Added "Confirm Password" field to signup form to prevent password typos
+  - Real-time validation to ensure passwords match before submission
+  - Error messages displayed when passwords don't match
+  - Submit button disabled when passwords don't match
+  - Accessibility features:
+    - `aria-invalid` attribute on confirm password field when passwords mismatch
+    - `aria-describedby` linking to error message for screen readers
+    - Error messages with `role="alert"` for proper announcement
+  - Proper tab order: Name → Email → Password → Confirm Password
+  - Both password fields cleared on duplicate email error for security
+  - Comprehensive Cypress E2E test coverage for password confirmation validation
+  - Jest unit tests for password confirmation logic
+  - Updated existing signup tests to include confirm password field
 - **Terms of Service Page** (Issue #81)
   - Comprehensive Terms of Service page at `/terms`
   - Detailed sections covering all legal requirements:

--- a/cypress/e2e/auth-signup-password-confirmation.cy.ts
+++ b/cypress/e2e/auth-signup-password-confirmation.cy.ts
@@ -1,0 +1,96 @@
+describe('Signup Password Confirmation', () => {
+  beforeEach(() => {
+    cy.visit('/auth')
+    cy.contains('Sign Up').click()
+  })
+
+  it('should require password confirmation field', () => {
+    cy.get('#signup-password').should('exist')
+    cy.get('#signup-confirm-password').should('exist')
+  })
+
+  it('should show error when passwords do not match', () => {
+    cy.get('#signup-password').type('password123')
+    cy.get('#signup-confirm-password').type('differentpassword')
+    cy.get('#signup-confirm-password').blur()
+
+    cy.contains('Passwords do not match').should('be.visible')
+  })
+
+  it('should not show error when passwords match', () => {
+    cy.get('#signup-password').type('password123')
+    cy.get('#signup-confirm-password').type('password123')
+    cy.get('#signup-confirm-password').blur()
+
+    cy.contains('Passwords do not match').should('not.exist')
+  })
+
+  it('should disable submit button when passwords do not match', () => {
+    cy.get('#signup-name').type('Test User')
+    cy.get('#signup-email').type('test@example.com')
+    cy.get('#signup-password').type('password123')
+    cy.get('#signup-confirm-password').type('differentpassword')
+    cy.get('#signup-confirm-password').blur()
+
+    cy.get('button[type="submit"]').should('be.disabled')
+  })
+
+  it('should allow submission when passwords match', () => {
+    const timestamp = Date.now()
+    cy.get('#signup-name').type('Test User')
+    cy.get('#signup-email').type(`test${timestamp}@example.com`)
+    cy.get('#signup-password').type('password123')
+    cy.get('#signup-confirm-password').type('password123')
+
+    cy.get('button[type="submit"]').should('not.be.disabled')
+    cy.get('button[type="submit"]').click()
+
+    // Should show success message
+    cy.contains('Verify your email').should('be.visible')
+  })
+
+  it('should clear error when user corrects password', () => {
+    cy.get('#signup-password').type('password123')
+    cy.get('#signup-confirm-password').type('wrongpassword')
+    cy.get('#signup-confirm-password').blur()
+
+    cy.contains('Passwords do not match').should('be.visible')
+
+    // Clear and retype correct password
+    cy.get('#signup-confirm-password').clear()
+    cy.get('#signup-confirm-password').type('password123')
+    cy.get('#signup-confirm-password').blur()
+
+    cy.contains('Passwords do not match').should('not.exist')
+  })
+
+  it('should maintain tab order: Name → Email → Password → Confirm Password', () => {
+    cy.get('#signup-name').focus()
+    cy.focused().should('have.id', 'signup-name')
+
+    cy.focused().tab()
+    cy.focused().should('have.id', 'signup-email')
+
+    cy.focused().tab()
+    cy.focused().should('have.id', 'signup-password')
+
+    cy.focused().tab()
+    cy.focused().should('have.id', 'signup-confirm-password')
+  })
+
+  it('should show error with proper accessibility attributes', () => {
+    cy.get('#signup-password').type('password123')
+    cy.get('#signup-confirm-password').type('wrongpassword')
+    cy.get('#signup-confirm-password').blur()
+
+    // Check aria attributes
+    cy.get('#signup-confirm-password')
+      .should('have.attr', 'aria-invalid', 'true')
+      .should('have.attr', 'aria-describedby', 'password-error')
+
+    // Check error message has role alert
+    cy.get('#password-error')
+      .should('have.attr', 'role', 'alert')
+      .should('contain', 'Passwords do not match')
+  })
+})

--- a/cypress/e2e/auth-signup.cy.ts
+++ b/cypress/e2e/auth-signup.cy.ts
@@ -8,6 +8,7 @@ describe('Sign Up Flow', () => {
     cy.get('input[id="signup-name"]').should('be.visible')
     cy.get('input[id="signup-email"]').should('be.visible')
     cy.get('input[id="signup-password"]').should('be.visible')
+    cy.get('input[id="signup-confirm-password"]').should('be.visible')
     cy.get('button[type="submit"]').should('be.visible')
   })
 
@@ -20,6 +21,7 @@ describe('Sign Up Flow', () => {
     cy.get('input[id="signup-name"]').type('Test User')
     cy.get('input[id="signup-email"]').type('invalid-email')
     cy.get('input[id="signup-password"]').type('password123')
+    cy.get('input[id="signup-confirm-password"]').type('password123')
     cy.get('button[type="submit"]').click()
     cy.get('input[id="signup-email"]:invalid').should('exist')
   })
@@ -37,6 +39,7 @@ describe('Sign Up Flow', () => {
     cy.get('input[id="signup-name"]').type('Test User')
     cy.get('input[id="signup-email"]').type(`test${timestamp}@example.com`)
     cy.get('input[id="signup-password"]').type('password123')
+    cy.get('input[id="signup-confirm-password"]').type('password123')
     cy.get('button[type="submit"]').click()
 
     cy.contains('Verify your email').should('be.visible')
@@ -48,6 +51,7 @@ describe('Sign Up Flow', () => {
     cy.get('input[id="signup-name"]').type('Test User')
     cy.get('input[id="signup-email"]').type(`test${timestamp}@example.com`)
     cy.get('input[id="signup-password"]').type('password123')
+    cy.get('input[id="signup-confirm-password"]').type('password123')
     cy.get('button[type="submit"]').click()
 
     cy.get('button[type="submit"]').should('be.disabled')

--- a/src/components/auth/__tests__/AuthFormWithQuery.test.tsx
+++ b/src/components/auth/__tests__/AuthFormWithQuery.test.tsx
@@ -12,12 +12,13 @@ import { useRouter } from 'next/navigation';
 
 // Mock the hooks
 jest.mock('@/hooks/use-auth-query');
-jest.mock('next/navigation');
+jest.mock('next/navigation', () => ({
+  useRouter: jest.fn(),
+}));
 
 const mockUseSignIn = useSignIn as jest.MockedFunction<typeof useSignIn>;
 const mockUseSignUp = useSignUp as jest.MockedFunction<typeof useSignUp>;
 const mockUseSignInWithProvider = useSignInWithProvider as jest.MockedFunction<typeof useSignInWithProvider>;
-const mockUseRouter = useRouter as jest.MockedFunction<typeof useRouter>;
 
 describe('AuthFormWithQuery - Password Confirmation', () => {
   const mockPush = jest.fn();
@@ -27,10 +28,10 @@ describe('AuthFormWithQuery - Password Confirmation', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    mockUseRouter.mockReturnValue({
+    (useRouter as jest.Mock).mockReturnValue({
       push: mockPush,
       refresh: mockRefresh,
-    } as any);
+    });
 
     mockUseSignIn.mockReturnValue({
       mutateAsync: mockMutateAsync,

--- a/src/components/auth/__tests__/AuthFormWithQuery.test.tsx
+++ b/src/components/auth/__tests__/AuthFormWithQuery.test.tsx
@@ -1,0 +1,240 @@
+/**
+ * Jest unit tests for AuthFormWithQuery.tsx
+ * Tests password confirmation validation functionality
+ */
+
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { AuthFormWithQuery } from '../AuthFormWithQuery';
+import { useSignIn, useSignUp, useSignInWithProvider } from '@/hooks/use-auth-query';
+import { useRouter } from 'next/navigation';
+
+// Mock the hooks
+jest.mock('@/hooks/use-auth-query');
+jest.mock('next/navigation');
+
+const mockUseSignIn = useSignIn as jest.MockedFunction<typeof useSignIn>;
+const mockUseSignUp = useSignUp as jest.MockedFunction<typeof useSignUp>;
+const mockUseSignInWithProvider = useSignInWithProvider as jest.MockedFunction<typeof useSignInWithProvider>;
+const mockUseRouter = useRouter as jest.MockedFunction<typeof useRouter>;
+
+describe('AuthFormWithQuery - Password Confirmation', () => {
+  const mockPush = jest.fn();
+  const mockRefresh = jest.fn();
+  const mockMutateAsync = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockUseRouter.mockReturnValue({
+      push: mockPush,
+      refresh: mockRefresh,
+    } as any);
+
+    mockUseSignIn.mockReturnValue({
+      mutateAsync: mockMutateAsync,
+      isPending: false,
+    } as any);
+
+    mockUseSignUp.mockReturnValue({
+      mutateAsync: mockMutateAsync,
+      isPending: false,
+    } as any);
+
+    mockUseSignInWithProvider.mockReturnValue({
+      mutateAsync: mockMutateAsync,
+      isPending: false,
+    } as any);
+  });
+
+  describe('Password Confirmation Field', () => {
+    it('should render password confirmation field on signup tab', async () => {
+      const user = userEvent.setup();
+      render(<AuthFormWithQuery />);
+
+      await user.click(screen.getByRole('tab', { name: 'Sign Up' }));
+
+      expect(screen.getByLabelText('Password')).toBeInTheDocument();
+      expect(screen.getByLabelText('Confirm Password')).toBeInTheDocument();
+    });
+
+    it('should show error when passwords do not match', async () => {
+      const user = userEvent.setup();
+      render(<AuthFormWithQuery />);
+
+      await user.click(screen.getByRole('tab', { name: 'Sign Up' }));
+
+      const password = document.getElementById('signup-password') as HTMLInputElement;
+      const confirmPassword = document.getElementById('signup-confirm-password') as HTMLInputElement;
+
+      await user.type(password, 'password123');
+      await user.type(confirmPassword, 'differentpassword');
+
+      // Trigger validation by blurring the confirm password field
+      confirmPassword.blur();
+
+      await waitFor(() => {
+        expect(screen.getByText('Passwords do not match')).toBeInTheDocument();
+      });
+    });
+
+    it('should not show error when passwords match', async () => {
+      const user = userEvent.setup();
+      render(<AuthFormWithQuery />);
+
+      await user.click(screen.getByRole('tab', { name: 'Sign Up' }));
+
+      const password = document.getElementById('signup-password') as HTMLInputElement;
+      const confirmPassword = document.getElementById('signup-confirm-password') as HTMLInputElement;
+
+      await user.type(password, 'password123');
+      await user.type(confirmPassword, 'password123');
+
+      confirmPassword.blur();
+
+      await waitFor(() => {
+        expect(screen.queryByText('Passwords do not match')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should prevent form submission when passwords do not match', async () => {
+      const user = userEvent.setup();
+      render(<AuthFormWithQuery />);
+
+      await user.click(screen.getByRole('tab', { name: 'Sign Up' }));
+
+      const name = document.getElementById('signup-name') as HTMLInputElement;
+      const email = document.getElementById('signup-email') as HTMLInputElement;
+      const password = document.getElementById('signup-password') as HTMLInputElement;
+      const confirmPassword = document.getElementById('signup-confirm-password') as HTMLInputElement;
+
+      await user.type(name, 'Test User');
+      await user.type(email, 'test@example.com');
+      await user.type(password, 'password123');
+      await user.type(confirmPassword, 'wrongpassword');
+
+      confirmPassword.blur();
+
+      const submitButton = screen.getByRole('button', { name: /create account/i });
+
+      await waitFor(() => {
+        expect(submitButton).toBeDisabled();
+      });
+
+      await user.click(submitButton);
+
+      // Should not call the mutation
+      expect(mockMutateAsync).not.toHaveBeenCalled();
+    });
+
+    it('should allow form submission when passwords match', async () => {
+      mockMutateAsync.mockResolvedValue({});
+      const user = userEvent.setup();
+      render(<AuthFormWithQuery />);
+
+      await user.click(screen.getByRole('tab', { name: 'Sign Up' }));
+
+      const name = document.getElementById('signup-name') as HTMLInputElement;
+      const email = document.getElementById('signup-email') as HTMLInputElement;
+      const password = document.getElementById('signup-password') as HTMLInputElement;
+      const confirmPassword = document.getElementById('signup-confirm-password') as HTMLInputElement;
+
+      await user.type(name, 'Test User');
+      await user.type(email, 'test@example.com');
+      await user.type(password, 'password123');
+      await user.type(confirmPassword, 'password123');
+
+      const submitButton = screen.getByRole('button', { name: /create account/i });
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(mockMutateAsync).toHaveBeenCalledWith({
+          email: 'test@example.com',
+          password: 'password123',
+          fullName: 'Test User',
+        });
+      });
+    });
+
+    it('should clear error when user corrects confirm password', async () => {
+      const user = userEvent.setup();
+      render(<AuthFormWithQuery />);
+
+      await user.click(screen.getByRole('tab', { name: 'Sign Up' }));
+
+      const password = document.getElementById('signup-password') as HTMLInputElement;
+      const confirmPassword = document.getElementById('signup-confirm-password') as HTMLInputElement;
+
+      await user.type(password, 'password123');
+      await user.type(confirmPassword, 'wrongpassword');
+      confirmPassword.blur();
+
+      await waitFor(() => {
+        expect(screen.getByText('Passwords do not match')).toBeInTheDocument();
+      });
+
+      // Clear and retype correct password
+      await user.clear(confirmPassword);
+      await user.type(confirmPassword, 'password123');
+      confirmPassword.blur();
+
+      await waitFor(() => {
+        expect(screen.queryByText('Passwords do not match')).not.toBeInTheDocument();
+      });
+    });
+
+    it('should have proper accessibility attributes when passwords do not match', async () => {
+      const user = userEvent.setup();
+      render(<AuthFormWithQuery />);
+
+      await user.click(screen.getByRole('tab', { name: 'Sign Up' }));
+
+      const password = document.getElementById('signup-password') as HTMLInputElement;
+      const confirmPassword = document.getElementById('signup-confirm-password') as HTMLInputElement;
+
+      await user.type(password, 'password123');
+      await user.type(confirmPassword, 'wrongpassword');
+      confirmPassword.blur();
+
+      await waitFor(() => {
+        expect(confirmPassword).toHaveAttribute('aria-invalid', 'true');
+        expect(confirmPassword).toHaveAttribute('aria-describedby', 'password-error');
+
+        const errorMessage = screen.getByText('Passwords do not match');
+        expect(errorMessage).toHaveAttribute('role', 'alert');
+        expect(errorMessage).toHaveAttribute('id', 'password-error');
+      });
+    });
+
+    it('should clear both password fields on duplicate email error', async () => {
+      const duplicateError = new Error('User already registered');
+      (duplicateError as any).message = 'User already registered';
+
+      mockMutateAsync.mockRejectedValue(duplicateError);
+
+      const user = userEvent.setup();
+      render(<AuthFormWithQuery />);
+
+      await user.click(screen.getByRole('tab', { name: 'Sign Up' }));
+
+      const name = document.getElementById('signup-name') as HTMLInputElement;
+      const email = document.getElementById('signup-email') as HTMLInputElement;
+      const password = document.getElementById('signup-password') as HTMLInputElement;
+      const confirmPassword = document.getElementById('signup-confirm-password') as HTMLInputElement;
+
+      await user.type(name, 'Test User');
+      await user.type(email, 'existing@example.com');
+      await user.type(password, 'password123');
+      await user.type(confirmPassword, 'password123');
+
+      const submitButton = screen.getByRole('button', { name: /create account/i });
+      await user.click(submitButton);
+
+      await waitFor(() => {
+        expect(password).toHaveValue('');
+        expect(confirmPassword).toHaveValue('');
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closes #89

This PR adds a password confirmation field to the signup form to prevent users from making typos when creating their account password.

### Changes

- **Component Updates:**
  - Added `confirmPassword` and `passwordError` state to `AuthFormWithQuery` component
  - Added `validatePasswords()` function to check password match
  - Added Confirm Password input field with validation on blur
  - Submit button disabled when passwords don't match
  - Both password fields cleared on duplicate email error for security

- **Accessibility:**
  - `aria-invalid` attribute when passwords mismatch
  - `aria-describedby` linking to error message
  - Error messages with `role="alert"` for screen reader announcement
  - Proper tab order: Name → Email → Password → Confirm Password

- **Testing:**
  - New Cypress E2E test suite (`auth-signup-password-confirmation.cy.ts`)
    - Tests password confirmation field existence
    - Tests error display when passwords don't match
    - Tests no error when passwords match
    - Tests submit button disabled with mismatched passwords
    - Tests successful submission with matching passwords
    - Tests error clearing when password is corrected
    - Tests proper tab order
    - Tests accessibility attributes
  - New Jest unit test suite (`AuthFormWithQuery.test.tsx`)
    - Tests password confirmation field rendering
    - Tests validation logic
    - Tests form submission prevention/allowance
    - Tests accessibility attributes
    - Tests password field clearing on duplicate email error
  - Updated existing signup tests to include confirm password field

- **Documentation:**
  - Updated CHANGELOG.md with feature details

## Test Plan

- [x] Linter passes (`npm run lint`)
- [x] Build succeeds (`npm run build`)
- [x] CodeRabbit review completed
- [ ] Cypress E2E tests pass
- [ ] Jest unit tests pass
- [ ] Manual testing: signup form displays confirm password field
- [ ] Manual testing: error shown when passwords don't match
- [ ] Manual testing: submit disabled when passwords don't match
- [ ] Manual testing: successful signup when passwords match

## Screenshots

_Screenshots will be added during testing_

## Accessibility

This implementation follows WCAG 2.1 AA guidelines:
- Proper ARIA attributes for error states
- Error messages announced to screen readers
- Logical tab order maintained
- Visual error indicators with sufficient color contrast

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a Confirm Password field to sign-up with real-time match validation.
  - Submit button is disabled if passwords don’t match.
  - Both password fields are cleared when a duplicate email error occurs.

- Accessibility
  - aria-invalid and aria-describedby added for error states; error messages use role="alert".
  - Tab order set: Name → Email → Password → Confirm Password.

- Documentation
  - Changelog updated to document the password confirmation feature.

- Tests
  - Added Cypress E2E and Jest unit tests covering confirmation, validation, accessibility, and flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->