### PR TITLE
feat: enable Planning Poker on dashboard

### DIFF
--- a/cypress/e2e/dashboard-poker.cy.ts
+++ b/cypress/e2e/dashboard-poker.cy.ts
@@ -1,0 +1,28 @@
+describe('Dashboard Planning Poker', () => {
+  beforeEach(() => {
+    cy.login();
+    cy.visit('/dashboard');
+  });
+
+  it('should show Planning Poker as available', () => {
+    cy.contains('ScrumKit Poker').parent().within(() => {
+      cy.contains('Available Now').should('exist');
+      cy.contains('Coming Soon').should('not.exist');
+    });
+  });
+
+  it('should have enabled Planning Poker button', () => {
+    cy.contains('ScrumKit Poker').parent().within(() => {
+      cy.get('a[href="/poker"]').should('exist');
+      cy.contains('View Sessions').should('exist');
+    });
+  });
+
+  it('should navigate to poker sessions when clicked', () => {
+    cy.contains('ScrumKit Poker').parent().within(() => {
+      cy.get('a[href="/poker"]').click();
+    });
+
+    cy.url().should('match', /\/poker/);
+  });
+});

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -150,17 +150,18 @@ export default function DashboardPage() {
             </Magnet>
           </motion.div>
 
-          {/* Planning Poker Feature - Coming Soon */}
+          {/* Planning Poker Feature - Available */}
           <motion.div
             initial={{ opacity: 0, y: 20 }}
             animate={{ opacity: 1, y: 0 }}
             transition={{ duration: 0.5, delay: 0.5 }}
-            className="group relative p-8 rounded-2xl bg-gradient-to-br from-blue-950/30 to-cyan-950/30 border border-blue-500/20 opacity-75"
+            whileHover={{ scale: 1.02 }}
+            className="group relative p-8 rounded-2xl bg-gradient-to-br from-blue-950/30 to-cyan-950/30 border border-blue-500/20 hover:border-blue-500/40 transition-all"
           >
             <div className="absolute top-4 right-4">
-              <span className="px-3 py-1 rounded-full bg-blue-500/10 text-blue-400 text-xs font-medium">Coming Soon</span>
+              <span className="px-3 py-1 rounded-full bg-green-500/10 text-green-400 text-xs font-medium">Available Now</span>
             </div>
-            <div className="w-14 h-14 rounded-xl bg-blue-500/10 flex items-center justify-center mb-4">
+            <div className="w-14 h-14 rounded-xl bg-blue-500/10 flex items-center justify-center mb-4 group-hover:bg-blue-500/20 transition-colors">
               <CreditCard className="w-7 h-7 text-blue-500" />
             </div>
             <h3 className="text-2xl font-semibold mb-3">ScrumKit Poker</h3>
@@ -181,9 +182,20 @@ export default function DashboardPage() {
                 Velocity tracking
               </li>
             </ul>
-            <Button className="w-full bg-blue-500/10 hover:bg-blue-500/10 text-blue-400 border-blue-500/20 cursor-not-allowed" disabled>
-              Coming Soon
-            </Button>
+            <Magnet padding={20} magnetStrength={2}>
+              <Link href="/poker" className="block">
+                <StarBorder
+                  color="#3b82f6"
+                  speed="3s"
+                  className="w-full hover:scale-105 transition-transform duration-200"
+                >
+                  <span className="flex items-center justify-center px-4 py-2.5 font-medium text-blue-400">
+                    View Sessions
+                    <ArrowRight className="ml-2 h-4 w-4" />
+                  </span>
+                </StarBorder>
+              </Link>
+            </Magnet>
           </motion.div>
 
           {/* Daily Standup Feature - Coming Soon */}


### PR DESCRIPTION
## Summary
- Updates the Planning Poker card on the dashboard from "Coming Soon" to "Available Now"
- Enables the Planning Poker button with a link to `/poker` sessions page
- Adds hover effects and visual consistency with the Retro card
- Includes Cypress E2E tests to validate the changes

## Changes Made
- Changed badge from "Coming Soon" to "Available Now" (green color)
- Removed `opacity-75` class from the Planning Poker card
- Added `whileHover={{ scale: 1.02 }}` animation effect
- Added hover border transition (`hover:border-blue-500/40`)
- Replaced disabled button with active link using Magnet and StarBorder components
- Updated button text to "View Sessions" with ArrowRight icon
- Added icon hover effect (`group-hover:bg-blue-500/20`)

## Testing
- Created `cypress/e2e/dashboard-poker.cy.ts` with E2E tests:
  - Verifies "Available Now" badge is displayed
  - Confirms "Coming Soon" is not shown
  - Validates the link to `/poker` is present and enabled
  - Tests navigation when clicking the Planning Poker button

## Validation
- ✅ Linter passed (no new errors)
- ✅ Build completed successfully
- ✅ Visual consistency with ScrumKit Retro card maintained

Closes #97

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Planning Poker is now available on the dashboard with an enabled “View Sessions” action linking to the poker page.
  - Updated status badge shows “Available Now.”

- UI/Style
  - Enhanced Planning Poker card visuals with hover effects, animated icon background, and clearer emphasis to reflect availability.

- Tests
  - Added end-to-end tests validating the “Available Now” status, enabled action/link to the poker page, presence of “View Sessions,” and successful navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->