### PR TITLE
Fix: Auto-switch to active tab when unarchiving last board

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Board Archive Navigation** (Issue #99)
+  - Fixed auto-switch to active tab when unarchiving the last archived board
+  - Replaced setTimeout-based callback with useEffect for reliable state tracking
+  - Added user-friendly toast notification when auto-switching views
+  - Prevents dead-end UX where users are stuck on empty archived tab
+  - Comprehensive Cypress E2E test coverage for archive navigation scenarios
+
 ### Added
 
 - **Settings Page** (Issue #93)

--- a/cypress/e2e/board-archive-navigation.cy.ts
+++ b/cypress/e2e/board-archive-navigation.cy.ts
@@ -1,0 +1,159 @@
+describe('Board Archive Navigation', () => {
+  beforeEach(() => {
+    cy.clearLocalStorage()
+    cy.visit('/boards')
+  })
+
+  it('should auto-switch to active tab when unarchiving last archived board', () => {
+    // Create a single board
+    cy.visit('/boards/new')
+    cy.get('input[id="title"]').type('Only Archived Board')
+    cy.contains('button', 'Create Board').click()
+
+    // Go back to boards page
+    cy.visit('/boards')
+
+    // Archive the board
+    cy.contains('Only Archived Board')
+      .parents('[data-testid="board-card"]')
+      .within(() => {
+        cy.get('button[aria-haspopup="menu"]').click()
+      })
+    cy.contains('Archive').click()
+
+    // Verify board is archived
+    cy.contains('Only Archived Board').should('not.exist')
+    cy.contains(/Archived.*1/i).should('be.visible')
+
+    // Switch to archived view
+    cy.contains('button', /Archived/i).click()
+    cy.contains('Only Archived Board').should('be.visible')
+    cy.contains('Show Active').should('be.visible')
+
+    // Unarchive the board
+    cy.contains('Only Archived Board')
+      .parents('[data-testid="board-card"]')
+      .within(() => {
+        cy.get('button[aria-haspopup="menu"]').click()
+      })
+    cy.contains('Restore Board').click()
+
+    // Should auto-switch to active tab
+    cy.contains('Switched to active boards').should('be.visible')
+    cy.contains('Show Active').should('not.exist')
+    cy.contains('Only Archived Board').should('be.visible')
+
+    // Archived button should not be visible when count is 0
+    cy.contains('button', /Archived/i).should('not.exist')
+  })
+
+  it('should keep archived view when multiple boards remain after unarchiving', () => {
+    // Create two boards
+    cy.visit('/boards/new')
+    cy.get('input[id="title"]').type('Archived Board 1')
+    cy.contains('button', 'Create Board').click()
+
+    cy.visit('/boards/new')
+    cy.get('input[id="title"]').type('Archived Board 2')
+    cy.contains('button', 'Create Board').click()
+
+    cy.visit('/boards')
+
+    // Archive both boards
+    cy.contains('Archived Board 1')
+      .parents('[data-testid="board-card"]')
+      .within(() => {
+        cy.get('button[aria-haspopup="menu"]').click()
+      })
+    cy.contains('Archive').click()
+
+    cy.contains('Archived Board 2')
+      .parents('[data-testid="board-card"]')
+      .within(() => {
+        cy.get('button[aria-haspopup="menu"]').click()
+      })
+    cy.contains('Archive').click()
+
+    // Switch to archived view
+    cy.contains('button', /Archived.*2/i).click()
+
+    // Verify both boards are visible
+    cy.contains('Archived Board 1').should('be.visible')
+    cy.contains('Archived Board 2').should('be.visible')
+    cy.contains('Show Active').should('be.visible')
+
+    // Unarchive one board
+    cy.contains('Archived Board 1')
+      .parents('[data-testid="board-card"]')
+      .within(() => {
+        cy.get('button[aria-haspopup="menu"]').click()
+      })
+    cy.contains('Restore Board').click()
+
+    // Should stay in archived view
+    cy.contains('Show Active').should('be.visible')
+    cy.contains('Archived Board 2').should('be.visible')
+    cy.contains('Archived Board 1').should('not.exist')
+
+    // Should NOT auto-switch or show success toast
+    cy.contains('Switched to active boards').should('not.exist')
+  })
+
+  it('should not show archived button when no archived boards exist', () => {
+    // Create a single active board
+    cy.visit('/boards/new')
+    cy.get('input[id="title"]').type('Active Board Only')
+    cy.contains('button', 'Create Board').click()
+
+    cy.visit('/boards')
+
+    // Archived button should not be visible
+    cy.contains('button', /Archived/i).should('not.exist')
+
+    // Board should be visible in active view
+    cy.contains('Active Board Only').should('be.visible')
+  })
+
+  it('should handle rapid archive/unarchive operations', () => {
+    // Create a single board
+    cy.visit('/boards/new')
+    cy.get('input[id="title"]').type('Rapid Test Board')
+    cy.contains('button', 'Create Board').click()
+
+    cy.visit('/boards')
+
+    // Archive the board
+    cy.contains('Rapid Test Board')
+      .parents('[data-testid="board-card"]')
+      .within(() => {
+        cy.get('button[aria-haspopup="menu"]').click()
+      })
+    cy.contains('Archive').click()
+
+    // Switch to archived view
+    cy.contains('button', /Archived/i).click()
+
+    // Unarchive
+    cy.contains('Rapid Test Board')
+      .parents('[data-testid="board-card"]')
+      .within(() => {
+        cy.get('button[aria-haspopup="menu"]').click()
+      })
+    cy.contains('Restore Board').click()
+
+    // Should be in active view
+    cy.contains('Rapid Test Board').should('be.visible')
+    cy.contains('button', /Archived/i).should('not.exist')
+
+    // Archive again
+    cy.contains('Rapid Test Board')
+      .parents('[data-testid="board-card"]')
+      .within(() => {
+        cy.get('button[aria-haspopup="menu"]').click()
+      })
+    cy.contains('Archive').click()
+
+    // Should show archived count
+    cy.contains('button', /Archived.*1/i).should('be.visible')
+  })
+})

--- a/src/app/boards/page.tsx
+++ b/src/app/boards/page.tsx
@@ -6,13 +6,14 @@ import { useBoards } from "@/hooks/use-boards";
 import { BoardList } from "@/components/BoardList";
 import { Button } from "@/components/ui/button";
 import { Plus, LayoutGrid, Sparkles, Archive } from "lucide-react";
-import { useState, useMemo } from "react";
+import { useState, useMemo, useEffect } from "react";
 import Magnet from "@/components/Magnet";
 import StarBorder from "@/components/StarBorder";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Header } from "@/components/layout/Header";
 import { useUser, useResendVerificationEmail } from "@/hooks/use-auth-query";
 import { EmailVerificationBanner } from "@/components/auth/EmailVerificationBanner";
+import { toast } from "sonner";
 
 export default function BoardsPage() {
   const [showArchived, setShowArchived] = useState(false);
@@ -27,20 +28,15 @@ export default function BoardsPage() {
   const archivedBoards = useMemo(() => boards.filter(board => board.is_archived), [boards]);
   const displayedBoards = showArchived ? archivedBoards : activeBoards;
 
-  // Auto-redirect when last archived board is unarchived
-  const handleArchiveStatusChange = () => {
-    // The query will automatically refetch due to mutation invalidation
-    // Check if we need to switch views
-    if (showArchived) {
-      // Small delay to ensure data is updated
-      setTimeout(() => {
-        const currentArchivedCount = boards.filter(b => b.is_archived).length;
-        if (currentArchivedCount === 0) {
-          setShowArchived(false);
-        }
-      }, 100);
+  // Auto-switch to active tab when last archived board is unarchived
+  useEffect(() => {
+    if (showArchived && archivedBoards.length === 0) {
+      setShowArchived(false);
+      toast.success('Switched to active boards', {
+        description: 'No archived boards remaining'
+      });
     }
-  };
+  }, [archivedBoards.length, showArchived]);
 
   if (isLoading) {
     return (
@@ -253,7 +249,6 @@ export default function BoardsPage() {
           <BoardList
             boards={displayedBoards}
             showArchived={showArchived}
-            onArchiveStatusChange={handleArchiveStatusChange}
           />
         </motion.div>
 

--- a/src/components/BoardList.tsx
+++ b/src/components/BoardList.tsx
@@ -50,10 +50,9 @@ interface Board {
 interface BoardListProps {
   boards: Board[];
   showArchived?: boolean;
-  onArchiveStatusChange?: () => void;
 }
 
-export function BoardList({ boards, showArchived = false, onArchiveStatusChange }: BoardListProps) {
+export function BoardList({ boards, showArchived = false }: BoardListProps) {
   const [loadingBoardId, setLoadingBoardId] = useState<string | null>(null);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [boardToDelete, setBoardToDelete] = useState<Board | null>(null);
@@ -70,11 +69,6 @@ export function BoardList({ boards, showArchived = false, onArchiveStatusChange 
         uniqueUrl: board.unique_url,
         updates: { is_archived: !board.is_archived }
       });
-
-      // Notify parent component about archive status change
-      if (onArchiveStatusChange) {
-        onArchiveStatusChange();
-      }
     } finally {
       setLoadingBoardId(null);
     }

--- a/src/components/BoardList.tsx
+++ b/src/components/BoardList.tsx
@@ -134,6 +134,7 @@ export function BoardList({ boards, showArchived = false }: BoardListProps) {
             whileHover={{ y: -4 }}
           >
             <Card
+              data-testid="board-card"
               className={`hover:shadow-lg transition-all ${
                 board.is_archived ? "opacity-60" : ""
               }`}


### PR DESCRIPTION
## Summary
Fixes issue #99 by implementing automatic tab switching when users unarchive the last archived board, preventing them from being stuck on an empty archived boards view.

## Changes Made

### Core Functionality
- **Replaced callback approach with useEffect**: Changed from `setTimeout`-based `handleArchiveStatusChange` callback to a React `useEffect` hook that monitors `archivedBoards.length`
- **Reliable state tracking**: The useEffect dependency array `[archivedBoards.length, showArchived]` ensures the component reacts immediately when the archived count changes
- **User feedback**: Added toast notification when auto-switching views using sonner

### Component Updates
- `src/app/boards/page.tsx`:
  - Removed `handleArchiveStatusChange` function
  - Added `useEffect` hook to monitor archived board count
  - Added toast notification for better UX
  - Removed `onArchiveStatusChange` prop from `<BoardList>`
  
- `src/components/BoardList.tsx`:
  - Removed `onArchiveStatusChange` prop from interface
  - Removed callback invocation in `handleArchive` function
  - Simplified component by removing callback logic

### Testing
- Created comprehensive E2E test suite: `cypress/e2e/board-archive-navigation.cy.ts`
  - ✅ Auto-switch when unarchiving the last archived board
  - ✅ Stay in archived view when multiple boards remain
  - ✅ No archived button shown when count is zero
  - ✅ Rapid archive/unarchive operations

### Documentation
- Updated `CHANGELOG.md` with fix details

## Test Plan

### Manual Testing
1. Create a single board
2. Archive it
3. Switch to archived view
4. Unarchive it
5. **Expected**: Automatically switch to active view with toast notification

### E2E Tests
Run: `npm run cypress -- --spec "cypress/e2e/board-archive-navigation.cy.ts"`

## Technical Details

**Before**: Used `setTimeout` with potentially stale closure state
```typescript
const handleArchiveStatusChange = () => {
  if (showArchived) {
    setTimeout(() => {
      const currentArchivedCount = boards.filter(b => b.is_archived).length;
      if (currentArchivedCount === 0) {
        setShowArchived(false);
      }
    }, 100);
  }
};
```

**After**: React to state changes with useEffect
```typescript
useEffect(() => {
  if (showArchived && archivedBoards.length === 0) {
    setShowArchived(false);
    toast.success('Switched to active boards', {
      description: 'No archived boards remaining'
    });
  }
}, [archivedBoards.length, showArchived]);
```

## Benefits
- ✅ Eliminates dead-end UX
- ✅ More React-idiomatic solution
- ✅ Reliable state synchronization
- ✅ Better user feedback with toast
- ✅ Simpler code (removed callback prop drilling)

## Checklist
- [x] Code follows project conventions
- [x] Linter passes (warnings only, no errors)
- [x] Build succeeds
- [x] E2E tests created
- [x] CHANGELOG updated
- [x] Commits are clear and well-structured
- [ ] E2E tests pass (requires dev server)
- [ ] Manual testing completed

Closes #99

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a toast notification when the view auto-switches after unarchiving the last archived board.

- Bug Fixes
  - Automatically switches from Archived to Active when the final archived board is restored.
  - Prevents users from getting stuck on an empty Archived view.
  - Ensures consistent behavior when multiple boards exist and during rapid archive/unarchive actions.

- Tests
  - Added end-to-end coverage for archive navigation, including auto-switch, multi-board behavior, empty states, and rapid actions.

- Documentation
  - Updated changelog to reflect archive navigation improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->