### PR TITLE
Fix export modal content overflow with scrollable content area

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Export Modal Content Overflow** (Issue #102)
+  - Fixed export modal layout to prevent content overflow and button cutoff
+  - Added flex-column layout with scrollable content area
+  - Header and footer sections now remain fixed and visible
+  - Content area (export options and preview) scrolls independently
+  - Added data-testid attributes for improved testability
+  - Ensures all action buttons (Copy, Download, Close) are always accessible
+  - Improves UX when exporting retrospectives with many items
+
 - **Board Archive Navigation** (Issue #99)
   - Fixed auto-switch to active tab when unarchiving the last archived board
   - Replaced setTimeout-based callback with useEffect for reliable state tracking

--- a/src/components/retro/ExportDialog.tsx
+++ b/src/components/retro/ExportDialog.tsx
@@ -88,8 +88,11 @@ export function ExportDialog({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-3xl max-h-[80vh]">
-        <DialogHeader>
+      <DialogContent
+        className="max-w-3xl max-h-[80vh] flex flex-col"
+        data-testid="export-modal"
+      >
+        <DialogHeader className="flex-shrink-0">
           <DialogTitle className="flex items-center gap-2">
             <FileText className="h-5 w-5" />
             Export Retrospective
@@ -100,7 +103,10 @@ export function ExportDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-4">
+        <div
+          className="flex-1 overflow-y-auto min-h-0 space-y-4"
+          data-testid="export-content"
+        >
           <div className="space-y-3">
             <div className="flex items-center justify-between">
               <Label htmlFor="grouped-export" className="flex flex-col gap-1">
@@ -157,11 +163,12 @@ export function ExportDialog({
               value={markdownContent}
               readOnly
               className="font-mono text-sm min-h-[300px] resize-none"
+              data-testid="export-preview"
             />
           </div>
         </div>
 
-        <DialogFooter className="gap-2 sm:gap-0">
+        <DialogFooter className="flex-shrink-0 gap-2 sm:gap-0" data-testid="modal-footer">
           <Button variant="outline" onClick={handleCopyToClipboard}>
             <Copy className="h-4 w-4 mr-2" />
             Copy to Clipboard


### PR DESCRIPTION
## Summary
Fixes the export modal content overflow issue where buttons were cut off and inaccessible when retrospectives had many items.

## Changes
- Added flex-column layout to `DialogContent` for proper content flow
- Made header section fixed (non-scrolling) with `flex-shrink-0`
- Made content area scrollable with `flex-1 overflow-y-auto min-h-0`
- Made footer section fixed (non-scrolling) with `flex-shrink-0`
- Added `data-testid` attributes for improved testability

## Technical Details
The issue was that the export modal used a fixed max-height (`max-h-[80vh]`) but didn't have a proper flex layout to manage overflow. When the content (export options + preview textarea) exceeded the available space, the footer buttons would be pushed off-screen.

The fix applies the standard modal layout pattern:
1. DialogContent as flex container (`flex flex-col`)
2. Header as fixed section (`flex-shrink-0`)
3. Content as scrollable flex item (`flex-1 overflow-y-auto min-h-0`)
4. Footer as fixed section (`flex-shrink-0`)

This ensures the header and footer remain visible while the middle content area scrolls independently.

## Testing
- ✅ Linter passed with no new warnings
- ✅ Build completed successfully
- ✅ Manually tested with various content sizes
- ✅ Verified all buttons remain accessible

## Resolves
Closes #102

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved export modal content overflow.
  * Enabled independent scrolling for modal content.
  * Kept header and footer fixed for better actions visibility.
  * Improved layout consistency across screen sizes.

* **Accessibility**
  * Enhanced structure and focus behavior in the export modal for better keyboard and screen reader support.

* **Documentation**
  * Updated changelog to reflect export modal fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->