### PR TITLE
Add back navigation to retrospective boards and poker sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Back Navigation to Boards and Sessions** (Issue #103)
+  - Added back navigation button to retrospective board page
+  - Added back navigation button to poker session page
+  - Implemented Esc key shortcut to navigate back to boards list
+  - Back button intelligently avoids navigation when modals are open
+  - Responsive design: text hidden on mobile, icon-only button
+  - Comprehensive Cypress E2E test coverage for navigation scenarios
+  - Improves UX by providing clear navigation path without relying on browser controls
+
 ### Fixed
 
 - **Export Modal Content Overflow** (Issue #102)

--- a/cypress/e2e/retro-board-navigation.cy.ts
+++ b/cypress/e2e/retro-board-navigation.cy.ts
@@ -1,0 +1,91 @@
+describe('Retrospective Board Navigation', () => {
+  beforeEach(() => {
+    cy.clearLocalStorage();
+    cy.visit('/boards/new');
+    cy.get('input[id="title"]').type('Navigation Test Board');
+    cy.contains('button', 'Create Board').click();
+    cy.url().should('include', '/retro/', { timeout: 10000 });
+    cy.contains('What went well', { timeout: 10000 }).should('be.visible');
+  });
+
+  it('should have back button to boards list', () => {
+    // Should be on board page
+    cy.url().should('include', '/retro/');
+
+    // Should have back button visible
+    cy.get('[data-testid="back-to-boards"]').should('be.visible');
+
+    // Back button should have arrow icon
+    cy.get('[data-testid="back-to-boards"]').find('svg').should('be.visible');
+  });
+
+  it('should navigate to boards list when clicking back button', () => {
+    // Verify we're on the board page
+    cy.url().should('include', '/retro/');
+    cy.contains('Navigation Test Board').should('be.visible');
+
+    // Click the back button
+    cy.get('[data-testid="back-to-boards"]').click();
+
+    // Should navigate to boards list
+    cy.url().should('include', '/boards');
+    cy.url().should('not.include', '/retro/');
+  });
+
+  it('should navigate back on Esc key press', () => {
+    // Verify we're on the board page
+    cy.url().should('include', '/retro/');
+
+    // Press Esc key
+    cy.get('body').type('{esc}');
+
+    // Should navigate to boards list
+    cy.url().should('include', '/boards');
+    cy.url().should('not.include', '/retro/');
+  });
+
+  it('should not navigate on Esc when export dialog is open', () => {
+    // Open export dialog
+    cy.contains('button', 'Export').click();
+
+    // Verify dialog is open (check for dialog content)
+    cy.contains('Export Retrospective').should('be.visible');
+
+    // Press Esc key
+    cy.get('body').type('{esc}');
+
+    // Should still be on board page (Esc closes dialog, not navigate)
+    cy.url().should('include', '/retro/');
+  });
+
+  it('should not navigate on Esc when adding an item', () => {
+    // Click Add Item button for first column
+    cy.get('button').contains('Add Item').first().click();
+
+    // Verify textarea is visible
+    cy.get('textarea').should('be.visible');
+
+    // Press Esc key
+    cy.get('body').type('{esc}');
+
+    // Should still be on board page (Esc cancels adding item)
+    cy.url().should('include', '/retro/');
+
+    // Textarea should be hidden (add mode cancelled)
+    cy.get('textarea').should('not.exist');
+  });
+
+  it('back button should be responsive on mobile', () => {
+    // Set mobile viewport
+    cy.viewport('iphone-x');
+
+    // Back button should still be visible
+    cy.get('[data-testid="back-to-boards"]').should('be.visible');
+
+    // Text may be hidden on mobile, but button should work
+    cy.get('[data-testid="back-to-boards"]').click();
+
+    // Should navigate to boards list
+    cy.url().should('include', '/boards');
+  });
+});

--- a/src/app/poker/[sessionUrl]/page.tsx
+++ b/src/app/poker/[sessionUrl]/page.tsx
@@ -9,12 +9,14 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { TrendingUp, Calendar, Settings } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { TrendingUp, Calendar, Settings, ArrowLeft } from "lucide-react";
 import { getSequenceByType } from "@/lib/poker/utils";
 import { format } from "date-fns";
 import { StoryManager } from "@/components/poker/StoryManager";
 import { SessionSummary } from "@/components/poker/SessionSummary";
 import { ExportButton } from "@/components/poker/ExportButton";
+import Link from "next/link";
 
 export default async function PokerSessionPage({
   params,
@@ -43,13 +45,19 @@ export default async function PokerSessionPage({
         {/* Session Header */}
         <div className="mb-8">
           <div className="flex items-start justify-between gap-4">
-            <div>
+            <div className="flex-1">
               <div className="mb-2 flex items-center gap-3">
+                <Link href="/poker" data-testid="back-to-poker">
+                  <Button variant="ghost" size="sm" className="gap-1.5">
+                    <ArrowLeft className="h-4 w-4" />
+                    <span className="hidden sm:inline">Back to Sessions</span>
+                  </Button>
+                </Link>
                 <TrendingUp className="h-8 w-8 text-indigo-500" />
                 <h1 className="text-4xl font-bold">{session.title}</h1>
               </div>
               {session.description && (
-                <p className="text-muted-foreground mt-2 text-lg">
+                <p className="text-muted-foreground mt-2 text-lg ml-[120px] sm:ml-[160px]">
                   {session.description}
                 </p>
               )}

--- a/src/components/RetrospectiveBoard.tsx
+++ b/src/components/RetrospectiveBoard.tsx
@@ -28,7 +28,10 @@ import {
   Star,
   Settings2,
   Palette,
+  ArrowLeft,
 } from "lucide-react";
+import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { DraggableRetroItem } from "@/components/retro/DraggableRetroItem";
 import type { RetroItemData } from "@/components/retro/RetroItem";
 import type { DraggableItem } from "@/types/drag-and-drop";
@@ -152,6 +155,7 @@ export function RetrospectiveBoard({
   teamName = "Development Team",
   sprintName = "Current Sprint",
 }: RetrospectiveBoardProps) {
+  const router = useRouter();
   const boardRef = useRef<HTMLDivElement>(null);
   const [newItemText, setNewItemText] = useState("");
   const [activeColumn, setActiveColumn] = useState<string | null>(null);
@@ -251,6 +255,25 @@ export function RetrospectiveBoard({
 
     return () => clearInterval(interval);
   }, []);
+
+  // Handle Esc key to navigate back to boards list
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      // Only navigate back if Esc is pressed and no modals are open
+      if (
+        e.key === "Escape" &&
+        !exportDialogOpen &&
+        !customizationDialogOpen &&
+        !facilitatorPanelOpen &&
+        !activeColumn // Don't navigate if adding an item
+      ) {
+        router.push("/boards");
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [router, exportDialogOpen, customizationDialogOpen, facilitatorPanelOpen, activeColumn]);
 
   const handleAddItem = async (columnId: string) => {
     // Validate input
@@ -611,11 +634,19 @@ export function RetrospectiveBoard({
       <div className="relative min-h-screen p-4 pt-24 md:px-8 md:pt-24 md:pb-8" ref={boardRef}>
       {/* Header */}
       <div className="mb-6 flex justify-between items-center">
-        <div>
-          <h1 className="text-3xl font-bold mb-1">
-            {retrospective?.title || sprintName}
-          </h1>
-          <p className="text-muted-foreground">{teamName}</p>
+        <div className="flex items-center gap-4">
+          <Link href="/boards" data-testid="back-to-boards">
+            <Button variant="ghost" size="sm" className="gap-1.5">
+              <ArrowLeft className="h-4 w-4" />
+              <span className="hidden sm:inline">Back to Boards</span>
+            </Button>
+          </Link>
+          <div>
+            <h1 className="text-3xl font-bold mb-1">
+              {retrospective?.title || sprintName}
+            </h1>
+            <p className="text-muted-foreground">{teamName}</p>
+          </div>
         </div>
         <div className="flex items-center gap-3 flex-wrap">
           {/* Facilitator State Indicators */}


### PR DESCRIPTION
## Summary

Adds back navigation buttons and keyboard shortcuts to improve navigation between boards/sessions and their list pages.

### Changes Made

- ✅ Added back navigation button to retrospective board page (`/retro/[id]`)
- ✅ Added back navigation button to poker session page (`/poker/[sessionUrl]`)
- ✅ Implemented Esc key shortcut for quick navigation back
- ✅ Intelligent modal detection to prevent unwanted navigation
- ✅ Responsive design with mobile-friendly button layout
- ✅ Comprehensive Cypress E2E test suite
- ✅ Updated CHANGELOG.md

### Implementation Details

**Retrospective Board (`src/components/RetrospectiveBoard.tsx`):**
- Added ArrowLeft icon and "Back to Boards" button in header
- Esc key handler with modal state checks (export dialog, customization, facilitator panel, active column)
- Button text hidden on small screens, icon-only for mobile

**Poker Session (`src/app/poker/[sessionUrl]/page.tsx`):**
- Added ArrowLeft icon and "Back to Sessions" button in header
- Maintains consistent navigation pattern across the app

**Testing (`cypress/e2e/retro-board-navigation.cy.ts`):**
- Back button visibility and click navigation
- Esc key navigation functionality
- Modal interference prevention
- Mobile responsiveness
- Edge cases for active item creation state

### Acceptance Criteria

- [x] Add back/close button to board page header
- [x] Button navigates to `/boards`
- [x] Use clear iconography (ArrowLeft icon)
- [x] Position in top-left of header
- [x] Add keyboard shortcut (Esc key to go back)
- [x] Include Cypress E2E tests

### Testing

Run the E2E tests:
```bash
npm run cypress -- --spec "cypress/e2e/retro-board-navigation.cy.ts"
```

Manual testing:
1. Create or open a retrospective board
2. Click "Back to Boards" button → should navigate to `/boards`
3. Open a board again, press Esc → should navigate to `/boards`
4. Open export dialog, press Esc → dialog closes, stays on board
5. Test on mobile viewport → button should show icon only

### Screenshots

_Screenshots to be added after UI review_

Closes #103

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added back navigation on Retrospective Boards and Poker Sessions.
  - Esc key now returns to the boards list when no modal or add-item flow is active.
  - Improved responsive behavior: icon-only back button on mobile; refined header layout and alignment.

- Tests
  - Introduced end-to-end tests covering back button visibility, Esc behavior with/without dialogs, add-item state handling, URL changes, and mobile viewport scenarios.

- Documentation
  - Updated changelog to include the new back navigation feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->